### PR TITLE
Enhance/sandbox bypass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ venv
 .vscode
 .DS_Store
 .python-version
+nocommit.*
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ sendgrid_django.egg-info
 .eggs
 venv
 .idea
+.vscode
 .DS_Store
 .python-version
 # Byte-compiled / optimized / DLL files

--- a/changeset.md
+++ b/changeset.md
@@ -1,0 +1,7 @@
+# Fork Changes 
+Changes made in this fork include:
+- upgrade sendgrid python dependancy support from <4 to 5.6
+- add mail_settings configuration support
+- add bypass list management configuration support (to bypass unsub password reset)
+- add sandbox configuration support
+- customize sandbox mode to support bypassing with a whitelist

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,4 @@ pytest
 pytest-cov
 pytest-django
 Django
-sendgrid>=5.6
+sendgrid==5.6.0

--- a/sgbackend/mail.py
+++ b/sgbackend/mail.py
@@ -1,3 +1,4 @@
+from sgbackend.sandbox_settings import can_enable_sandbox_mode
 from .version import __version__
 
 import base64
@@ -114,18 +115,8 @@ class SendGridBackend(BaseEmailBackend):
             mail_settings.bypass_list_management = BypassListManagement(email.bypass_list_management)
             
         #Check for sandbox mode
-        sandbox_mode = getattr(settings, "SENDGRID_SANDBOX", False)
-        if sandbox_mode:
-            sandbox_whitelist_domains = getattr(settings, "SENDGRID_SANDBOX_WHITELIST_DOMAINS", [])
-            sandbox_whitelist = False
-            for e in email.to:
-                domain = e.split('@')[1]
-                if domain in sandbox_whitelist_domains:
-                    sandbox_whitelist = True
-
-            if not sandbox_whitelist:
-                mail_settings.sandbox_mode = SandBoxMode(sandbox_mode)
-
+        if can_enable_sandbox_mode(email.to):
+            mail_settings.sandbox_mode = SandBoxMode(True)
 
         if hasattr(email, 'template_id'):
             mail.template_id = email.template_id

--- a/sgbackend/mail.py
+++ b/sgbackend/mail.py
@@ -47,8 +47,6 @@ class SendGridBackend(BaseEmailBackend):
             raise ImproperlyConfigured('''
                 SENDGRID_API_KEY must be declared in settings.py''')
 
-
-
         self.sg = sendgrid.SendGridAPIClient(apikey=self.api_key)
         self.version = 'sendgrid/{0};django'.format(__version__)
         self.sg.client.request_headers['User-agent'] = self.version

--- a/sgbackend/sandbox_settings.py
+++ b/sgbackend/sandbox_settings.py
@@ -1,0 +1,32 @@
+from django.conf import settings
+
+def get_sandbox_bypass_whitelist():
+    # @deprecated - use SENDGRID_SANDBOX_BYPASS_WHITELIST instead
+    sandbox_whitelist_domains = getattr(
+        settings, "SENDGRID_SANDBOX_WHITELIST_DOMAINS", []
+    )
+    sandbox_bypass_whitelist = getattr(
+        settings, "SENDGRID_SANDBOX_BYPASS_WHITELIST", []
+    )
+    for sandbox_whitelist_domain in sandbox_whitelist_domains:
+        sandbox_bypass_whitelist.append(sandbox_whitelist_domain)
+    return list(set(sandbox_bypass_whitelist)) # Ensure unique
+
+def can_bypass_sandbox_setting(to_address, sandbox_bypass_whitelist):
+    to_address_domain = to_address.split('@')[1]
+    return (
+        to_address in sandbox_bypass_whitelist
+        or to_address_domain in sandbox_bypass_whitelist
+    )
+
+# Note that sandbox mode setting will be bypassed if ANY match is found in the 
+# whitelist, not if ALL "to" addresses match
+def can_enable_sandbox_mode(to_addresses = []):
+    wants_sandbox_mode = getattr(settings, "SENDGRID_SANDBOX", False)
+    if not wants_sandbox_mode:
+        return False
+    sandbox_bypass_whitelist = get_sandbox_bypass_whitelist()
+    for to_address in to_addresses:
+        if can_bypass_sandbox_setting(to_address, sandbox_bypass_whitelist):
+            return False
+    return True

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -210,7 +210,7 @@ class SendGridBackendTests(TestCase):
                  'subject': ''}
             )
 
-    def test_list_mgmt_bypass_true(self):
+    def test_list_management_bypass_true(self):
         msg = EmailMessage()
         msg.bypass_list_management = True
         with self.settings(SENDGRID_API_KEY='test_key'):
@@ -228,7 +228,7 @@ class SendGridBackendTests(TestCase):
                  'subject': ''}
             )
 
-    def test_list_mgmt_bypass_false(self):
+    def test_list_management_bypass_false(self):
         msg = EmailMessage()
         msg.bypass_list_management = False
         with self.settings(SENDGRID_API_KEY='test_key'):
@@ -278,9 +278,7 @@ class SendGridBackendTests(TestCase):
                 {'content': [{'type': 'text/plain', 'value': ''}],
                  'from': {'email': 'webmaster@localhost'},
                  'personalizations': [{'subject': '', 'to': [
-                     {
-                         'email': 'test@example.com'
-                     }
+                     {'email': 'test@example.com'}
                  ]}],
                  'mail_settings': {
                      'sandbox_mode': {
@@ -302,12 +300,8 @@ class SendGridBackendTests(TestCase):
                 {'content': [{'type': 'text/plain', 'value': ''}],
                  'from': {'email': 'webmaster@localhost'},
                  'personalizations': [{'subject': '', 'to': [
-                     {
-                         'email': 'test@example.com'
-                     },
-                     {
-                         'email': 'test@example.org'
-                     }
+                     {'email': 'test@example.com'},
+                     {'email': 'test@example.org'}
                  ]}],
                  'mail_settings': {
                      'sandbox_mode': {
@@ -317,7 +311,7 @@ class SendGridBackendTests(TestCase):
                  'subject': ''}
             )
 
-    def test_sandbox_true_with_domain_whitelist_match_none(self):
+    def test_sandbox_true_w_domain_whitelist_match_none(self):
         msg = EmailMessage(to=['test@example.com','test@example.net'])
         with self.settings(
             SENDGRID_API_KEY='test_key',
@@ -330,12 +324,8 @@ class SendGridBackendTests(TestCase):
                 {'content': [{'type': 'text/plain', 'value': ''}],
                  'from': {'email': 'webmaster@localhost'},
                  'personalizations': [{'subject': '', 'to': [
-                     {
-                         'email': 'test@example.com'
-                     },
-                     {
-                         'email': 'test@example.net'
-                     }
+                     {'email': 'test@example.com'},
+                     {'email': 'test@example.net'}
                  ]}],
                  'mail_settings': {
                      'sandbox_mode': {
@@ -345,7 +335,7 @@ class SendGridBackendTests(TestCase):
                  'subject': ''}
             )
 
-    def test_sandbox_true_with_domain_whitelist_match_single(self):
+    def test_sandbox_true_w_domain_whitelist_match_single(self):
         msg = EmailMessage(to=[
             'test@example.com',
             'test@example.net',
@@ -361,18 +351,14 @@ class SendGridBackendTests(TestCase):
                 {'content': [{'type': 'text/plain', 'value': ''}],
                  'from': {'email': 'webmaster@localhost'},
                  'personalizations': [{'subject': '', 'to': [
-                     {
-                         'email': 'test@example.com'
-                     },
-                     {
-                         'email': 'test@example.net'
-                     }
+                     {'email': 'test@example.com'},
+                     {'email': 'test@example.net'}
                  ]}],
                  'mail_settings': {},
                  'subject': ''}
             )
 
-    def test_sandbox_true_with_domain_whitelist_match_all(self):
+    def test_sandbox_true_w_domain_whitelist_match_all(self):
         msg = EmailMessage(to=['test@example.com', 'test@example.org'])
         with self.settings(
             SENDGRID_API_KEY='test_key',
@@ -385,25 +371,20 @@ class SendGridBackendTests(TestCase):
                 {'content': [{'type': 'text/plain', 'value': ''}],
                  'from': {'email': 'webmaster@localhost'},
                  'personalizations': [{'subject': '', 'to': [
-                     {
-                         'email': 'test@example.com'
-                     },
-                     {
-                         'email': 'test@example.org'
-                     }
+                     {'email': 'test@example.com'},
+                     {'email': 'test@example.org'}
                  ]}],
                  'mail_settings': {},
                  'subject': ''}
             )
 
-    def test_sandbox_true_with_bypass_whitelist_match_none(self):
+    def test_sandbox_true_w_regex_whitelist_address(self):
         msg = EmailMessage(to=['test@example.com'])
+        msg_2 = EmailMessage(to=['test-test@example.com'])
         with self.settings(
             SENDGRID_API_KEY='test_key',
             SENDGRID_SANDBOX=True,
-            SENDGRID_SANDBOX_BYPASS_WHITELIST=[
-                'foo.com', 'test@example.org', 'foo@example.com'
-            ]
+            SENDGRID_SANDBOX_WHITELIST_REGEX=['^test@example.com$']
         ):
             mail = SendGridBackend()._build_sg_mail(msg)
             self.assertEqual(
@@ -411,9 +392,18 @@ class SendGridBackendTests(TestCase):
                 {'content': [{'type': 'text/plain', 'value': ''}],
                  'from': {'email': 'webmaster@localhost'},
                  'personalizations': [{'subject': '', 'to': [
-                     {
-                         'email': 'test@example.com'
-                     }
+                     {'email': 'test@example.com'}
+                 ]}],
+                 'mail_settings': {},
+                 'subject': ''}
+            )
+            mail = SendGridBackend()._build_sg_mail(msg_2)
+            self.assertEqual(
+                mail,
+                {'content': [{'type': 'text/plain', 'value': ''}],
+                 'from': {'email': 'webmaster@localhost'},
+                 'personalizations': [{'subject': '', 'to': [
+                     {'email': 'test-test@example.com'}
                  ]}],
                  'mail_settings': {
                      'sandbox_mode': {
@@ -423,12 +413,13 @@ class SendGridBackendTests(TestCase):
                  'subject': ''}
             )
 
-    def test_sandbox_true_with_bypass_whitelist_match_single_email(self):
+    def test_sandbox_true_w_regex_whitelist_domain(self):
         msg = EmailMessage(to=['test@example.com'])
+        msg_2 = EmailMessage(to=['test@example.com.au'])
         with self.settings(
             SENDGRID_API_KEY='test_key',
             SENDGRID_SANDBOX=True,
-            SENDGRID_SANDBOX_BYPASS_WHITELIST=['test@example.com']
+            SENDGRID_SANDBOX_WHITELIST_REGEX=['.*@example.com$']
         ):
             mail = SendGridBackend()._build_sg_mail(msg)
             self.assertEqual(
@@ -436,91 +427,18 @@ class SendGridBackendTests(TestCase):
                 {'content': [{'type': 'text/plain', 'value': ''}],
                  'from': {'email': 'webmaster@localhost'},
                  'personalizations': [{'subject': '', 'to': [
-                     {
-                         'email': 'test@example.com'
-                     }
+                     {'email': 'test@example.com'}
                  ]}],
                  'mail_settings': {},
                  'subject': ''}
             )
-
-    def test_sandbox_true_with_bypass_whitelist_match_single_domain(self):
-        msg = EmailMessage(to=['test@example.com'])
-        with self.settings(
-            SENDGRID_API_KEY='test_key',
-            SENDGRID_SANDBOX=True,
-            SENDGRID_SANDBOX_BYPASS_WHITELIST=['example.com']
-        ):
-            mail = SendGridBackend()._build_sg_mail(msg)
+            mail = SendGridBackend()._build_sg_mail(msg_2)
             self.assertEqual(
                 mail,
                 {'content': [{'type': 'text/plain', 'value': ''}],
                  'from': {'email': 'webmaster@localhost'},
                  'personalizations': [{'subject': '', 'to': [
-                     {
-                         'email': 'test@example.com'
-                     }
-                 ]}],
-                 'mail_settings': {},
-                 'subject': ''}
-            )
-
-    def test_sandbox_true_with_bypass_whitelist_match_all(self):
-        msg = EmailMessage(
-            to=['test@example.com', 'test@example.org', 'test@example.net']
-        )
-        with self.settings(
-            SENDGRID_API_KEY='test_key',
-            SENDGRID_SANDBOX=True,
-            SENDGRID_SANDBOX_BYPASS_WHITELIST=[
-                'test@example.com', 'test@example.org', 'test@example.net'
-            ]
-        ):
-            mail = SendGridBackend()._build_sg_mail(msg)
-            self.assertEqual(
-                mail,
-                {'content': [{'type': 'text/plain', 'value': ''}],
-                 'from': {'email': 'webmaster@localhost'},
-                 'personalizations': [{'subject': '', 'to': [
-                     {
-                         'email': 'test@example.com'
-                     },
-                     {
-                         'email': 'test@example.org'
-                     },
-                     {
-                         'email': 'test@example.net'
-                     }
-                 ]}],
-                 'mail_settings': {},
-                 'subject': ''}
-            )
-
-    def test_sandbox_true_with_bypass_and_domain_whitelist_match_none(self):
-        msg = EmailMessage(
-            to=['test@example.com', 'test@example.org', 'test@example.net']
-        )
-        with self.settings(
-            SENDGRID_API_KEY='test_key',
-            SENDGRID_SANDBOX=True,
-            SENDGRID_SANDBOX_WHITELIST_DOMAINS=['example.xyz'],
-            SENDGRID_SANDBOX_BYPASS_WHITELIST=['example.abc', 'test@example.def']
-        ):
-            mail = SendGridBackend()._build_sg_mail(msg)
-            self.assertEqual(
-                mail,
-                {'content': [{'type': 'text/plain', 'value': ''}],
-                 'from': {'email': 'webmaster@localhost'},
-                 'personalizations': [{'subject': '', 'to': [
-                     {
-                         'email': 'test@example.com'
-                     },
-                     {
-                         'email': 'test@example.org'
-                     },
-                     {
-                         'email': 'test@example.net'
-                     }
+                     {'email': 'test@example.com.au'}
                  ]}],
                  'mail_settings': {
                      'sandbox_mode': {
@@ -530,15 +448,13 @@ class SendGridBackendTests(TestCase):
                  'subject': ''}
             )
 
-    def test_sandbox_true_with_bypass_and_domain_whitelist_match_email(self):
-        msg = EmailMessage(
-            to=['test@example.com', 'test@example.org', 'test@example.net']
-        )
+    def test_sandbox_true_w_regex_whitelist_username(self):
+        msg = EmailMessage(to=['test@example.com'])
+        msg_2 = EmailMessage(to=['test-test@example.com'])
         with self.settings(
             SENDGRID_API_KEY='test_key',
             SENDGRID_SANDBOX=True,
-            SENDGRID_SANDBOX_WHITELIST_DOMAINS=['example.xyz'],
-            SENDGRID_SANDBOX_BYPASS_WHITELIST=['test@example.com']
+            SENDGRID_SANDBOX_WHITELIST_REGEX=['^test@.*$']
         ):
             mail = SendGridBackend()._build_sg_mail(msg)
             self.assertEqual(
@@ -546,29 +462,36 @@ class SendGridBackendTests(TestCase):
                 {'content': [{'type': 'text/plain', 'value': ''}],
                  'from': {'email': 'webmaster@localhost'},
                  'personalizations': [{'subject': '', 'to': [
-                     {
-                         'email': 'test@example.com'
-                     },
-                     {
-                         'email': 'test@example.org'
-                     },
-                     {
-                         'email': 'test@example.net'
-                     }
+                     {'email': 'test@example.com'}
                  ]}],
                  'mail_settings': {},
                  'subject': ''}
             )
-    
-    def test_sandbox_true_with_bypass_and_domain_whitelist_match_domain(self):
-        msg = EmailMessage(
-            to=['test@example.com', 'test@example.org', 'test@example.net']
-        )
+            mail = SendGridBackend()._build_sg_mail(msg_2)
+            self.assertEqual(
+                mail,
+                {'content': [{'type': 'text/plain', 'value': ''}],
+                 'from': {'email': 'webmaster@localhost'},
+                 'personalizations': [{'subject': '', 'to': [
+                     {'email': 'test-test@example.com'}
+                 ]}],
+                 'mail_settings': {
+                     'sandbox_mode': {
+                         'enable': True
+                     }
+                 },
+                 'subject': ''}
+            )
+
+    def test_sandbox_true_w_domain_and_regex_whitelist(self):
+        msg = EmailMessage(to=['test@example.com'])
+        msg_2 = EmailMessage(to=['test@example.net'])
+        msg_3 = EmailMessage(to=['test@example.org'])
         with self.settings(
             SENDGRID_API_KEY='test_key',
             SENDGRID_SANDBOX=True,
             SENDGRID_SANDBOX_WHITELIST_DOMAINS=['example.com'],
-            SENDGRID_SANDBOX_BYPASS_WHITELIST=['foo@example.com']
+            SENDGRID_SANDBOX_WHITELIST_REGEX=['^test@example.net$']
         ):
             mail = SendGridBackend()._build_sg_mail(msg)
             self.assertEqual(
@@ -576,98 +499,34 @@ class SendGridBackendTests(TestCase):
                 {'content': [{'type': 'text/plain', 'value': ''}],
                  'from': {'email': 'webmaster@localhost'},
                  'personalizations': [{'subject': '', 'to': [
-                     {
-                         'email': 'test@example.com'
-                     },
-                     {
-                         'email': 'test@example.org'
-                     },
-                     {
-                         'email': 'test@example.net'
-                     }
+                     {'email': 'test@example.com'}
                  ]}],
                  'mail_settings': {},
                  'subject': ''}
             )
-
-    def test_sandbox_true_with_bypass_and_domain_whitelist_match_both(self):
-        msg = EmailMessage(
-            to=['test@example.com', 'test@example.org', 'test@example.net']
-        )
-        with self.settings(
-            SENDGRID_API_KEY='test_key',
-            SENDGRID_SANDBOX=True,
-            SENDGRID_SANDBOX_WHITELIST_DOMAINS=['example.com'],
-            SENDGRID_SANDBOX_BYPASS_WHITELIST=['example.com', 'test@example.com']
-        ):
-            mail = SendGridBackend()._build_sg_mail(msg)
+            mail = SendGridBackend()._build_sg_mail(msg_2)
             self.assertEqual(
                 mail,
                 {'content': [{'type': 'text/plain', 'value': ''}],
                  'from': {'email': 'webmaster@localhost'},
                  'personalizations': [{'subject': '', 'to': [
-                     {
-                         'email': 'test@example.com'
-                     },
-                     {
-                         'email': 'test@example.org'
-                     },
-                     {
-                         'email': 'test@example.net'
-                     }
+                     {'email': 'test@example.net'}
                  ]}],
                  'mail_settings': {},
                  'subject': ''}
             )
-
-    def test_sandbox_true_bypass_and_domain_whitelist_duplicates_no_match(self):
-        msg = EmailMessage(to=['test@example.com'])
-        with self.settings(
-            SENDGRID_API_KEY='test_key',
-            SENDGRID_SANDBOX=True,
-            SENDGRID_SANDBOX_WHITELIST_DOMAINS=['example.org', 'example.net'],
-            SENDGRID_SANDBOX_BYPASS_WHITELIST=[
-                'test@example.org', 'example.org', 'example.net'
-            ]
-        ):
-            mail = SendGridBackend()._build_sg_mail(msg)
+            mail = SendGridBackend()._build_sg_mail(msg_3)
             self.assertEqual(
                 mail,
                 {'content': [{'type': 'text/plain', 'value': ''}],
                  'from': {'email': 'webmaster@localhost'},
                  'personalizations': [{'subject': '', 'to': [
-                     {
-                         'email': 'test@example.com'
-                     }
+                     {'email': 'test@example.org'}
                  ]}],
                  'mail_settings': {
                      'sandbox_mode': {
                          'enable': True
                      }
                  },
-                 'subject': ''}
-            )
-
-    def test_sandbox_true_bypass_and_domain_whitelist_duplicates_with_match(self):
-        msg = EmailMessage(to=['test@example.com'])
-        with self.settings(
-            SENDGRID_API_KEY='test_key',
-            SENDGRID_SANDBOX=True,
-            SENDGRID_SANDBOX_WHITELIST_DOMAINS=['example.org', 'example.net'],
-            SENDGRID_SANDBOX_BYPASS_WHITELIST=[
-                'test@example.org', 'example.org', 'example.net', 'test@example.com'
-            ]
-        ):
-            mail = SendGridBackend()._build_sg_mail(msg)
-            self.assertEqual(
-                mail,
-                {'content': [{'type': 'text/plain', 'value': ''}],
-                 'from': {'email': 'webmaster@localhost'},
-                 'personalizations': [{'subject': '', 'to': [
-                     {
-                         'email': 'test@example.com'
-                     }
-                 ]}],
-                 'mail_settings': {},
                  'subject': ''}
             )

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -3,32 +3,10 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.mail import EmailMessage
 from django.core.mail import EmailMultiAlternatives
 from django.test import SimpleTestCase as TestCase
-from python_http_client.client import HTTPError
-from python_http_client.client import Client, Response
-from python_http_client.exceptions import handle_error
 
 from sgbackend import SendGridBackend
 
 settings.configure()
-
-
-class MockException(HTTPError):
-    def __init__(self, code):
-        self.code = code
-        self.reason = 'REASON'
-        self.hdrs = 'HEADERS'
-
-    def read(self):
-        return 'BODY'
-
-
-class MockClient(Client):
-    def __init__(self, host):
-        self.response_code = 400
-        Client.__init__(self, host)
-
-    def _make_request(self, opener, request):
-        raise handle_error(MockException(self.response_code))
 
 
 class SendGridBackendTests(TestCase):
@@ -48,6 +26,7 @@ class SendGridBackendTests(TestCase):
                 mail,
                 {'from': {'email': 'webmaster@localhost'},
                  'subject': '',
+                 'mail_settings': {},
                  'content': [{'type': 'text/plain', 'value': ''}],
                  'personalizations': [{'subject': ''}]}
             )
@@ -62,6 +41,7 @@ class SendGridBackendTests(TestCase):
                  'personalizations': [
                      {'to': [{'email': 'andrii.soldatenko@test.com'}],
                       'subject': ''}],
+                  'mail_settings': {},
                  'from': {'email': 'webmaster@localhost'}, 'subject': ''}
             )
 
@@ -75,6 +55,7 @@ class SendGridBackendTests(TestCase):
                  'personalizations': [
                      {'cc': [{'email': 'andrii.soldatenko@test.com'}],
                       'subject': ''}],
+                      'mail_settings': {},
                  'from': {'email': 'webmaster@localhost'}, 'subject': ''}
             )
 
@@ -88,6 +69,7 @@ class SendGridBackendTests(TestCase):
                  'personalizations': [
                      {'bcc': [{'email': 'andrii.soldatenko@test.com'}],
                       'subject': ''}],
+                      'mail_settings': {},
                  'from': {'email': 'webmaster@localhost'}, 'subject': ''}
             )
 
@@ -101,6 +83,7 @@ class SendGridBackendTests(TestCase):
                 mail,
                 {'content': [{'value': '', 'type': 'text/plain'}],
                  'personalizations': [{'subject': ''}],
+                 'mail_settings': {},
                  'reply_to': {'email': 'andrii.soldatenko@test.com'},
                  'from': {'email': 'webmaster@localhost'}, 'subject': ''}
             )
@@ -112,6 +95,7 @@ class SendGridBackendTests(TestCase):
                 mail,
                 {'content': [{'value': '', 'type': 'text/plain'}],
                  'personalizations': [{'subject': ''}],
+                 'mail_settings': {},
                  'reply_to': {'email': 'andrii.soldatenko@test.com'},
                  'from': {'email': 'webmaster@localhost'}, 'subject': ''}
             )
@@ -124,6 +108,7 @@ class SendGridBackendTests(TestCase):
                 mail,
                 {'content': [{'value': '', 'type': 'text/plain'}],
                  'personalizations': [{'subject': ''}],
+                 'mail_settings': {},
                  'reply_to': {
                     'name': 'Andrii Soldatenko',
                     'email': 'andrii.soldatenko@test.com'},
@@ -145,6 +130,7 @@ class SendGridBackendTests(TestCase):
                                        'message.</p>'}],
                  'from': {'email': 'webmaster@localhost'},
                  'personalizations': [{'subject': ''}],
+                 'mail_settings': {},
                  'subject': ''}
             )
 
@@ -159,6 +145,7 @@ class SendGridBackendTests(TestCase):
                  'content': [{'type': 'text/plain', 'value': ''}],
                  'from': {'email': 'webmaster@localhost'},
                  'personalizations': [{'subject': ''}],
+                 'mail_settings': {},
                  'subject': ''
                  }
             )
@@ -174,7 +161,8 @@ class SendGridBackendTests(TestCase):
                  'content': [{'type': 'text/plain', 'value': ''}],
                  'from': {'email': 'webmaster@localhost'},
                  'personalizations': [{'subject': ''}],
-                 'subject': ''
+                 'subject': '',
+                 'mail_settings': {},
                  }
             )
 
@@ -188,6 +176,7 @@ class SendGridBackendTests(TestCase):
                 {'content': [{'type': 'text/plain', 'value': ''}],
                  'from': {'email': 'webmaster@localhost'},
                  'personalizations': [{'subject': ''}],
+                 'mail_settings': {},
                  'subject': ''}
             )
 
@@ -202,6 +191,7 @@ class SendGridBackendTests(TestCase):
                  'from': {'email': 'webmaster@localhost'},
                  'headers': {'EXTRA_HEADER': 'VALUE'},
                  'personalizations': [{'subject': ''}],
+                 'mail_settings': {},
                  'subject': ''}
             )
 
@@ -218,13 +208,6 @@ class SendGridBackendTests(TestCase):
                  'custom_args': {'custom_arg1': '12345-abcdef'},
                  'from': {'email': 'webmaster@localhost'},
                  'personalizations': [{'subject': ''}],
+                 'mail_settings': {},
                  'subject': ''}
             )
-            
-    def test_send_messages_error(self):
-        mock_client = MockClient(self.host)
-        backend = SendGridBackend()
-        backend.sg.client = mock_client
-        msg = EmailMessage()
-        with self.assertRaises(HTTPError):
-            backend.send_messages(emails=[SendGridBackend()._build_sg_mail(msg)])


### PR DESCRIPTION
# What
Add ability to bypass the sandbox True setting on emails with a whitelist by regex so that matches can be done on all parts of a to_address structure (full address, username, domain, ...).

Note that removed code in mail tests file include this commit: https://github.com/elbuo8/sendgrid-django/commit/243fb293658e05660a525f319ff822301bd504e8

# Why
Currently the sandbox setting can only be bypassed by domain. There is a need for finer grained control.

